### PR TITLE
Remove Numpy Cap

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
  - ipykernel
  - rasterio
  - shapely
- - numpy<2.0
+ - numpy
  - matplotlib
  - fiona
  - geopandas


### PR DESCRIPTION
- Remove numpy cap due to numpy 2.0 increase (which introduced breaking changes to pandera and fixed [here](https://github.com/unionai-oss/pandera/pull/1690)).